### PR TITLE
Fix issue with u'\u2019'

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ This is based on the Tactix 410mm organiser from bunnings warehouse. (410x330x60
 
 This is all Glued together, no other fixings needed for me. 
 
-I used 6mm ply for the shelves and 12mm for the sides. I have drawn a backing board in the design but I didn’t use it. I used some small angle brackets and used the existing plywood wall as the backing board. If you do want a backing board, its probably easier to cut this with a table or circular saw anyway as its just a rectangle!
+I used 6mm ply for the shelves and 12mm for the sides. I have drawn a backing board in the design but I didn't use it. I used some small angle brackets and used the existing plywood wall as the backing board. If you do want a backing board, its probably easier to cut this with a table or circular saw anyway as its just a rectangle!


### PR DESCRIPTION
The garden is grumpy this morning and keeps spitting out the error messsage: 

File "/var/www/html/generateHTML.py", line 443, in generatePagesForProjects
    f.write(pageHTML)
UnicodeEncodeError: 'ascii' codec can't encode character u'\u2019' in position 2612: ordinal not in range(128)

I believe for some reason python only supports this style of single quote ' and that is preventing the page for this awesome project from showing up